### PR TITLE
Fix: Adding changelog tables for campaign name + canvas name dimensions and filters in Braze Reporting

### DIFF
--- a/changelogs_campaign_shared.view.lkml
+++ b/changelogs_campaign_shared.view.lkml
@@ -1,0 +1,41 @@
+view: changelogs_campaign_shared {
+  sql_table_name: "DATALAKE_SHARING"."CHANGELOGS_CAMPAIGN_SHARED"
+    ;;
+  drill_fields: [id]
+
+  dimension: id {
+    primary_key: yes
+    type: string
+    sql: ${TABLE}."ID" ;;
+  }
+
+  dimension: api_id {
+    type: string
+    sql: ${TABLE}."API_ID" ;;
+  }
+
+  dimension: app_group_id {
+    type: string
+    sql: ${TABLE}."APP_GROUP_ID" ;;
+  }
+
+  dimension: conversion_behaviors {
+    type: string
+    sql: ${TABLE}."CONVERSION_BEHAVIORS" ;;
+  }
+
+  dimension: campaign_name {
+    type: string
+    sql: ${TABLE}."NAME" ;;
+  }
+
+  dimension: time {
+    type: number
+    sql: ${TABLE}."TIME" ;;
+  }
+
+  measure: count {
+    type: count
+    drill_fields: [id, campaign_name]
+  }
+}

--- a/changelogs_campaign_shared.view.lkml
+++ b/changelogs_campaign_shared.view.lkml
@@ -30,7 +30,7 @@ view: changelogs_campaign_shared {
   }
 
   dimension: time {
-    type: number
+    type: date_time
     sql: ${TABLE}."TIME" ;;
   }
 

--- a/changelogs_canvas_shared.view.lkml
+++ b/changelogs_canvas_shared.view.lkml
@@ -30,7 +30,7 @@ view: changelogs_canvas_shared {
   }
 
   dimension: time {
-    type: number
+    type: date_time
     sql: ${TABLE}."TIME" ;;
   }
 

--- a/changelogs_canvas_shared.view.lkml
+++ b/changelogs_canvas_shared.view.lkml
@@ -1,0 +1,41 @@
+view: changelogs_canvas_shared {
+  sql_table_name: "DATALAKE_SHARING"."CHANGELOGS_CANVAS_SHARED"
+    ;;
+  drill_fields: [id]
+
+  dimension: id {
+    primary_key: yes
+    type: string
+    sql: ${TABLE}."ID" ;;
+  }
+
+  dimension: api_id {
+    type: string
+    sql: ${TABLE}."API_ID" ;;
+  }
+
+  dimension: app_group_id {
+    type: string
+    sql: ${TABLE}."APP_GROUP_ID" ;;
+  }
+
+  dimension: conversion_behaviors {
+    type: string
+    sql: ${TABLE}."CONVERSION_BEHAVIORS" ;;
+  }
+
+  dimension: name {
+    type: string
+    sql: ${TABLE}."NAME" ;;
+  }
+
+  dimension: time {
+    type: number
+    sql: ${TABLE}."TIME" ;;
+  }
+
+  measure: count {
+    type: count
+    drill_fields: [id, name]
+  }
+}

--- a/email_messaging_cadence.view.lkml
+++ b/email_messaging_cadence.view.lkml
@@ -41,7 +41,7 @@ view: email_messaging_cadence {
       from DATALAKE_SHARING.CHANGELOGS_CANVAS_SHARED
       )
 
-      SELECT deliveries.*, campaign_name, canvas_name FROM deliveries
+      SELECT deliveries.*, clicks.*, opens.*, campaign_name, canvas_name FROM deliveries
       LEFT JOIN opens
       ON (deliveries.delivered_address)=(opens.open_address)
       AND ((deliveries.d_message_variation_api_id)=(opens.o_message_variation_api_id) OR (deliveries.d_canvas_step_api_id)=(opens.o_canvas_step_api_id))
@@ -50,10 +50,10 @@ view: email_messaging_cadence {
       AND ((deliveries.d_message_variation_api_id)=(clicks.c_message_variation_api_id) OR (deliveries.d_canvas_step_api_id)=(clicks.c_canvas_step_api_id))
       LEFT JOIN campaign
         ON (deliveries.d_campaign_id)=(campaign.campaign_id)
-        AND (deliveries.delivered_timestamp)>= (campaign.updated_timestamp)
+--        AND (deliveries.delivered_timestamp)>= (campaign.updated_timestamp)
       LEFT JOIN canvas
         ON (deliveries.d_canvas_id)=(canvas.canvas_id)
-        AND (deliveries.delivered_timestamp)>= (canvas.updated_timestamp)
+--        AND (deliveries.delivered_timestamp)>= (canvas.updated_timestamp)
       qualify row_number() over (partition by deliveries.delivered_id ORDER BY campaign.updated_timestamp, canvas.updated_timestamp DESC) = 1
       ;;
   }
@@ -107,7 +107,7 @@ view: email_messaging_cadence {
   dimension: message_variation_id {
     description: "message variation ID if from a campaign"
     type: string
-    sql: ${TABLE}."D_MESSAGE_VARIATION_ID" ;;
+    sql: ${TABLE}."D_MESSAGE_VARIATION_API_ID" ;;
   }
 
   dimension_group: delivery {
@@ -160,15 +160,15 @@ view: email_messaging_cadence {
   measure: unique_clicks {
     description: "distinct count of campaigns/canvases clicked per email address; may differ by less than 1% due to inability to link exact instances of emails delivered to emails clicked"
     type: number
-    sql: count(distinct ${TABLE}."CLICK_ADDRESS", ${TABLE}."C_MESSAGE_VARIATION_ID")
-      +count(distinct ${TABLE}."CLICK_ADDRESS", ${TABLE}."C_CANVAS_STEP_ID") ;;
+    sql: count(distinct ${TABLE}."CLICK_ADDRESS", ${TABLE}."C_MESSAGE_VARIATION_API_ID")
+      +count(distinct ${TABLE}."CLICK_ADDRESS", ${TABLE}."C_CANVAS_STEP_API_ID") ;;
   }
 
   measure: unique_opens {
     description: "distinct count of campaigns/canvases opened per email address; may differ by less than 1% due to inability to link exact instances of emails delivered to emails opened"
     type: number
-    sql: count(distinct ${TABLE}."OPEN_ADDRESS", ${TABLE}."O_MESSAGE_VARIATION_ID")
-      +count(distinct ${TABLE}."OPEN_ADDRESS", ${TABLE}."O_CANVAS_STEP_ID") ;;
+    sql: count(distinct ${TABLE}."OPEN_ADDRESS", ${TABLE}."O_MESSAGE_VARIATION_API_ID")
+      +count(distinct ${TABLE}."OPEN_ADDRESS", ${TABLE}."O_CANVAS_STEP_API_ID") ;;
   }
 
   measure: unique_open_rate {

--- a/email_messaging_cadence.view.lkml
+++ b/email_messaging_cadence.view.lkml
@@ -6,7 +6,8 @@ view: email_messaging_cadence {
       email_address AS delivered_address,
       message_variation_api_id as d_message_variation_api_id,
       canvas_step_api_id as d_canvas_step_api_id,
-      campaign_name as d_campaign_name,
+      campaign_id as d_campaign_id,
+      campaign_api_id as d_campaign_api_id
       canvas_name as d_canvas_name,
       id as delivered_id,
       rank() over (partition by delivered_address order by delivered_timestamp asc) as delivery_event,
@@ -25,7 +26,14 @@ view: email_messaging_cadence {
       (select distinct email_address as click_address,
       message_variation_api_id as c_message_variation_api_id,
       canvas_step_api_id as c_canvas_step_api_id
-      FROM DATALAKE_SHARING.USERS_MESSAGES_EMAIL_CLICK_SHARED)
+      FROM DATALAKE_SHARING.USERS_MESSAGES_EMAIL_CLICK_SHARED),
+
+      campaign as (
+        select id as campaign_id,
+        name as campaign_name,
+        time as updated_timestamp
+      from DATALAKE_SHARING.CHANGELOGS_CAMPAIGN_SHARED
+      ),
 
       SELECT * FROM deliveries
       LEFT JOIN opens
@@ -34,24 +42,10 @@ view: email_messaging_cadence {
       LEFT JOIN clicks
       ON (deliveries.delivered_address)=(clicks.click_address)
       AND ((deliveries.d_message_variation_id)=(clicks.c_message_variation_id) OR (deliveries.d_canvas_step_id)=(clicks.c_canvas_step_id))
+      LEFT JOIN campaign
+      ON (deliveries.campaign_id)=(campaign.campaign_id)
       ;;
   }
-
-      # campaign_join as
-      # (select deliveries.*, campaign_name
-      # FROM deliveries
-      # LEFT JOIN campaign
-      # ON deliveries.campaign_id = campaign.campaign_id
-      # AND delivered_timestamp >= updated_timestamp
-      # qualify row_number() over (partition by delivered_id ORDER BY updated_timestamp DESC) = 1),
-
-      # SELECT * FROM campaign_join
-      # LEFT JOIN opens
-      # ON (campaign_join.delivered_address)=(opens.open_address)
-      # AND ((campaign_join.d_message_variation_api_id)=(opens.o_message_variation_api_id) OR (campaign_join.d_canvas_step_api_id)=(opens.o_canvas_step_api_id))
-      # LEFT JOIN clicks
-      # ON (campaign_join.delivered_address)=(clicks.click_address)
-      # AND ((campaign_join.d_message_variation_api_id)=(clicks.c_message_variation_api_id) OR (campaign_join.d_canvas_step_api_id)=(clicks.c_canvas_step_api_id))
 
 
   dimension: campaign_name {

--- a/email_messaging_cadence.view.lkml
+++ b/email_messaging_cadence.view.lkml
@@ -63,31 +63,31 @@ view: email_messaging_cadence {
   }
 
   dimension: campaign_name {
-    description: "campaign name if from a campaign"
+    description: "Campaign Name"
     type: string
     sql: ${TABLE}."CAMPAIGN_NAME" ;;
   }
 
   dimension: canvas_name {
-    description: "canvas name if from a canvas"
+    description: "Canvas nNme"
     type: string
     sql: ${TABLE}."CANVAS_NAME" ;;
   }
 
   dimension: canvas_step_id {
-    description: "canvas step ID if from a canvas"
+    description: "Canvas Step ID"
     type: string
     sql: ${TABLE}."D_CANVAS_STEP_API_ID" ;;
   }
 
   dimension: days_since_last_received {
-    description: "amount of time (days) between each email message variation/canvas step delivered to an email address (null if campaign/canvas only has one send per email address)"
+    description: "Days between each email message delivered to an email address (null for a single send)"
     type: number
     sql: ${TABLE}."DIFF_DAYS" ;;
   }
 
   dimension: days_since_last_received_tier {
-    description: "time ranges (days) between each email message variation/canvas step delivered to an email address (null if campaign/canvas only has one send per email address)"
+    description: "Tiered days between each email message delivered to an email address (null for a single send)"
     type: tier
     hidden: yes
     sql: COALESCE(${TABLE}."DIFF_DAYS",0) ;;
@@ -96,45 +96,47 @@ view: email_messaging_cadence {
   }
 
   dimension: email_address {
-    description: "email address of the user"
+    description: "Email address of the user"
     type: string
     sql: ${TABLE}."delivered_ADDRESS" ;;
   }
 
   dimension_group: first_delivered {
-    description: "UTC epoch timestamp the first push was delivered to this user"
+    description: "UTC epoch timestamp the first email was delivered to this user"
+    label: "First Delivered (UTC)"
     type: time
     timeframes: [date, time]
     sql: ${TABLE}."FIRST_DELIVERED" ;;
   }
 
   dimension: message_variation_id {
-    description: "message variation ID if from a campaign"
+    description: "Message variation ID if from a campaign"
     type: string
     sql: ${TABLE}."D_MESSAGE_VARIATION_API_ID" ;;
   }
 
   dimension_group: delivery {
     description: "UTC epoch timestamp the email was delivered"
+    label: "Delivered Time (UTC)"
     type: time
     timeframes: [date, time, hour_of_day]
     sql: ${TABLE}."DELIVERED_TIMESTAMP" ;;
   }
 
   dimension: delivery_event {
-    description: "time-based ranking (1st, 2nd, 3rd, etc.) of message variations/canvas steps delivered to an email address"
+    description: "Time-based ranking (1st, 2nd, 3rd, etc.) of message variations/canvas steps delivered to an email address"
     type: number
     sql: ${TABLE}."DELIVERY_EVENT" ;;
   }
 
   dimension: weeks_since_last_received {
-    description: "amount of time (weeeks) between each email message variation/canvas step delivered to an email address (null if campaign/canvas only has one send per email address)"
+    description: "Weeks between each email message delivered to an email address (null for a single send)"
     type: number
     sql: ${TABLE}."DIFF_WEEKS" ;;
   }
 
   dimension: weeks_since_last_received_tier {
-    description: "time ranges (weeks) between each email message variation/canvas step delivered to an email address (null if campaign/canvas only has one send per email address)"
+    description: "Tiered weeks between each email message delivered to an email address (null for a single send)"
     type: tier
     hidden: yes
     sql: COALESCE(${TABLE}."DIFF_WEEKS",0) ;;
@@ -143,47 +145,47 @@ view: email_messaging_cadence {
   }
 
   measure: average_number_of_days_since_last_received {
-    description: "average amount of time (days) between each email message variation/canvas step delivered to an email address (null if campaign/canvas only has one send per email address)"
+    description: "Average amount of days between each email delivered to an email address (null for a single send)"
     type: average
     value_format_name: decimal_0
     sql: ${TABLE}."DIFF_DAYS";;
   }
 
   measure: count_distinct_email_address {
-    description: "distinct count of email addresses"
+    description: "Count of unique email addresses"
     type: count_distinct
     sql: ${TABLE}."DELIVERED_ADDRESS" ;;
   }
 
   measure: emails_delivered {
-    description: "distinct count of delivery ids"
+    description: "Count of unique delivery ids"
     type: count_distinct
     sql: ${TABLE}."DELIVERED_ID" ;;
   }
 
   measure: unique_clicks {
-    description: "distinct count of campaigns/canvases clicked per email address; may differ by less than 1% due to inability to link exact instances of emails delivered to emails clicked"
+    description: "Total unique clicks of campaigns/canvases per email address"
     type: number
     sql: count(distinct ${TABLE}."CLICK_ADDRESS", ${TABLE}."C_MESSAGE_VARIATION_API_ID")
       +count(distinct ${TABLE}."CLICK_ADDRESS", ${TABLE}."C_CANVAS_STEP_API_ID") ;;
   }
 
   measure: unique_opens {
-    description: "distinct count of campaigns/canvases opened per email address; may differ by less than 1% due to inability to link exact instances of emails delivered to emails opened"
+    description: "Total unique opens of campaigns/canvases opened per email address"
     type: number
     sql: count(distinct ${TABLE}."OPEN_ADDRESS", ${TABLE}."O_MESSAGE_VARIATION_API_ID")
       +count(distinct ${TABLE}."OPEN_ADDRESS", ${TABLE}."O_CANVAS_STEP_API_ID") ;;
   }
 
   measure: unique_open_rate {
-    description: "email unique opens/deliveries"
+    description: "Email unique opens/deliveries"
     type: number
     value_format_name: percent_2
     sql: ${unique_opens}/${emails_delivered} ;;
   }
 
   measure: unique_click_rate {
-    description: "email unique opens/deliveries"
+    description: "Email unique opens/deliveries"
     type: number
     value_format_name: percent_2
     sql: ${unique_clicks}/${emails_delivered} ;;

--- a/email_messaging_cadence.view.lkml
+++ b/email_messaging_cadence.view.lkml
@@ -55,6 +55,7 @@ view: email_messaging_cadence {
       LEFT JOIN canvas
         ON (deliveries.canvas_id)=(canvas.canvas_id)
         AND (deliveries.delivered_timestamp)>= (canvas.updated_timestamp)
+      qualify row_number() over (partition by sends.id ORDER BY campaign_updated_timestamp, canvas_updated_timestamp DESC) = 1
       ;;
   }
 

--- a/email_messaging_frequency.view.lkml
+++ b/email_messaging_frequency.view.lkml
@@ -30,14 +30,12 @@ view: email_messaging_frequency {
         LEFT JOIN DATALAKE_SHARING.CHANGELOGS_CANVAS_SHARED as canvas on deliveries.canvas_id = canvas.id
           and deliveries.time >= canvas.time
       WHERE
-      {% condition campaign_name %} campaign.name {% endcondition %}
+      {% condition campaign_name %} campaign_name {% endcondition %}
       AND
       {% condition canvas_name %} canvas_name {% endcondition %}
       AND
       {% condition message_variation_id %} deliveries.message_variation_api_id {% endcondition %}
---      AND
---      {% condition canvas_name %} deliveries.canvas_step_id {% endcondition %}
-      qualify row_number() over (partition by delivered_id ORDER BY campaign.time, canvas.time DESC) = 1)
+      qualify row_number() over (partition by delivered_id ORDER BY  canvas.time, campaign.time DESC) = 1)
       ;;
   }
 

--- a/email_messaging_frequency.view.lkml
+++ b/email_messaging_frequency.view.lkml
@@ -40,13 +40,13 @@ view: email_messaging_frequency {
   }
 
   filter: campaign_name {
-    description: "name of the campaign"
+    description: "Campaign name"
     suggest_explore: users_messages_email_send
     suggest_dimension: campaign_name
   }
 
   filter: canvas_name {
-    description: "name of the canvas"
+    description: "Canvas name"
     suggest_explore: users_messages_email_send
     suggest_dimension: canvas_name
   }
@@ -58,13 +58,13 @@ view: email_messaging_frequency {
   # }
 
   filter: message_variation_id {
-    description: "message variation id if from a campaign"
+    description: "Message variation id if from a campaign"
     suggest_explore: users_messages_email_send
     suggest_dimension: message_variation_id
   }
 
   parameter: date_granularity {
-    description: "specify daily, weekly or monthly marketing pressure"
+    description: "Specify daily, weekly or monthly marketing pressure"
     type: string
     default_value: "day"
     allowed_value: {
@@ -79,7 +79,8 @@ view: email_messaging_frequency {
   }
 
   dimension_group: delivered_time {
-    description: "time the email was delivered (UTC)"
+    description: "Time email was delivered (UTC)"
+    label: "Delivered Time (UTC)"
     type: time
     timeframes: [hour_of_day,
       date,
@@ -91,87 +92,85 @@ view: email_messaging_frequency {
   }
 
   dimension: email_address {
-    description: "email address of the user"
+    description: "Email address of the user"
     type: string
     sql: ${TABLE}."DELIVERED_ADDRESS" ;;
   }
 
   dimension: frequency {
-    description: "number of emails sent per date granularity (day/week/month)"
+    description: "Number of emails sent per (day/week/month)"
     type: number
     sql: ${TABLE}."FREQUENCY" ;;
   }
 
   measure: emails_delivered {
-    description: "count of unique delivery event IDs"
+    description: "Unique email delivery events"
     type: sum
     sql: CASE WHEN rank=1 then ${frequency} else null end ;;
   }
 
   measure: unique_opens_mvid {
-    description: "unique opens corresponding to message variations"
+    description: "Unique opens corresponding to message variations"
     type: count_distinct
     hidden: yes
     sql: ${TABLE}."OPENED_ADDRESS", ${TABLE}."OPENED_MV_ID" ;;
   }
 
   measure: unique_opens_csid {
-    description: "unique opens corresponding to canvas steps"
+    description: "Unique opens corresponding to canvas steps"
     type: count_distinct
     hidden: yes
     sql: ${TABLE}."OPENED_ADDRESS", ${TABLE}."OPENED_CS_ID" ;;
   }
 
   measure: unique_clicks_mvid {
-    description: "unique clicks corresponding to message variations"
+    description: "Unique clicks corresponding to message variations"
     type: count_distinct
     hidden: yes
     sql: ${TABLE}."CLICKED_ADDRESS", ${TABLE}."CLICKED_MV_ID" ;;
   }
 
   measure: unique_clicks_csid {
-    description: "unique clicks corresponding to canvas steps"
+    description: "Unique clicks corresponding to canvas steps"
     type: count_distinct
     hidden: yes
     sql: ${TABLE}."CLICKED_ADDRESS", ${TABLE}."CLICKED_CS_ID" ;;
   }
 
   measure: unique_opens {
-    description: "distinct count of times a recipient opened an email campaign or canvas (does not count the same person opening the same campaign or canvas more than once);
-    expected behavior is for this measure to deviate from actual by less than 1% because of limitations on linking specific instances of emails delivered to emails opened"
+    description: "Times a recipient opened an email campaign or canvas (does not count the same person opening the same campaign or canvas more than once)"
     type: number
     sql: COALESCE(${unique_opens_mvid},0)+COALESCE(${unique_opens_csid},0);;
   }
 
   measure: unique_clicks {
-    description: "distinct count of times a recipient opened an email campaign or canvas (does not count the same person opening the same campaign or canvas more than once);
-    expected behavior is for this measure to deviate from actual by less than 1% because of limitations on linking specific instances of emails delivered to emails clicked"
+    description: "Times a recipient opened an email campaign or canvas (does not count the same person opening the same campaign or canvas more than once)"
     type: number
     sql: COALESCE(${unique_clicks_mvid},0)+COALESCE(${unique_clicks_csid},0) ;;
   }
 
   measure: delivery_occasions {
-    description: "occasions a certain frequency of emails was sent to a user per date granularity"
+    description: "Occasions certain frequency of emails was sent to a user by date granularity"
     type: number
     sql: COUNT(CASE WHEN rank=1 then ${frequency} else null end) ;;
   }
 
   measure: unique_click_rate {
-    description: "email unique clicks/emails delivered"
+    description: "Unique clicks/emails delivered"
     type: number
     value_format_name: percent_2
     sql: ${unique_clicks}/NULLIF(${emails_delivered},0) ;;
   }
 
   measure: unique_open_rate {
-    description: "email unique opens/emails delivered"
+    description: "Unique opens/emails delivered"
     type: number
     value_format_name: percent_2
     sql: ${unique_opens}/NULLIF(${emails_delivered},0) ;;
   }
 
   measure: unique_recipients {
-    description: "distinct count of email addresses that received an email campaign"
+    description: "Unique email addresses that received an email campaign"
     type: count_distinct
     sql: ${TABLE}."DELIVERED_ADDRESS" ;;
   }

--- a/users_messages_email_bounce.view.lkml
+++ b/users_messages_email_bounce.view.lkml
@@ -99,14 +99,14 @@ view: users_messages_email_bounce {
   }
 
   dimension: send_id {
-    description: "id of the message if specified for the campaign (See Send Identifier under REST API Parameter Definitions)"
+    description: "ID of message if specified for the campaign (See Send Identifier under REST API Parameter Definitions)"
     hidden: yes
     type: string
     sql: ${TABLE}."SEND_ID" ;;
   }
 
   dimension: sending_ip_bounce {
-    description: "the IP address from which the message was sent (only use for email bounce measures)"
+    description: "IP address from which the message was sent (only use for email bounce measures)"
     hidden: yes
     type: string
     drill_fields: [campaign_name, campaign_id, message_variation_id,canvas_step_id]
@@ -114,20 +114,20 @@ view: users_messages_email_bounce {
   }
 
   dimension: user_id {
-    description: "Braze id of the user"
+    description: "Braze ID of the user"
     hidden: yes
     type: string
     sql: ${TABLE}."USER_ID" ;;
   }
 
   measure: email_bounces {
-    description: "distinct count of email bounce event IDs"
+    description: "Count of email bounces"
     type: count_distinct
     sql: ${TABLE}."ID" ;;
   }
 
   measure: email_bounce_rate {
-    description: "email (hard) bounces/emails sent--may be over 100% at the user level"
+    description: "Count of (hard) bounces/emails sent--may be over 100% at the user level"
     type: number
     value_format_name: percent_2
     sql: ${email_bounces}/NULLIF(${users_messages_email_send.emails_sent},0) ;;

--- a/users_messages_email_click.view.lkml
+++ b/users_messages_email_click.view.lkml
@@ -26,7 +26,7 @@ view: users_messages_email_click {
         LEFT JOIN canvas
           ON clicks.canvas_id = canvas.canvas_id
           and time >= canvas_updated_timestamp
-        qualify row_number() over (partition by deliveries.id ORDER BY campaign_updated_timestamp, canvas_updated_timestamp DESC) = 1
+        qualify row_number() over (partition by clicks.id ORDER BY campaign_updated_timestamp, canvas_updated_timestamp DESC) = 1
       )
       select * from joined
       ;;

--- a/users_messages_email_send.view.lkml
+++ b/users_messages_email_send.view.lkml
@@ -22,10 +22,8 @@ view: users_messages_email_send {
         FROM sends
         LEFT JOIN campaign
           ON sends.campaign_id = campaign.campaign_id
-          AND time >= campaign_updated_timestamp
         LEFT JOIN canvas
           ON sends.canvas_id = canvas.canvas_id
-          and time >= canvas_updated_timestamp
         qualify row_number() over (partition by sends.id ORDER BY campaign_updated_timestamp, canvas_updated_timestamp DESC) = 1
       )
       select * from joined

--- a/users_messages_email_send.view.lkml
+++ b/users_messages_email_send.view.lkml
@@ -26,7 +26,7 @@ view: users_messages_email_send {
         LEFT JOIN canvas
           ON sends.canvas_id = canvas.canvas_id
           and time >= canvas_updated_timestamp
-        qualify row_number() over (partition by sends.id ORDER BY campaign_updated_timestamp DESC) = 1
+        qualify row_number() over (partition by sends.id ORDER BY campaign_updated_timestamp, canvas_updated_timestamp DESC) = 1
       )
       select * from joined
       ;;


### PR DESCRIPTION
campaign names come from a changelog table rather than the tables directly, because there is a structure to support renamed email

Added in the changelog into the users_messages_email_send and a few other tables